### PR TITLE
Function arguments should be after the function name

### DIFF
--- a/fish_command_timer.fish
+++ b/fish_command_timer.fish
@@ -146,7 +146,7 @@ function fish_command_timer_compute
 end
 
 # The fish_postexec event is fired after executing a command line.
-function -e fish_postexec fish_command_timer_postexec
+function fish_command_timer_postexec -e fish_postexec
   if not fish_command_timer_compute
     return
   end


### PR DESCRIPTION
Introduced with Fish version 2.5, fixes issue #13.