### PR TITLE
Add minimum command duration threshold setting.

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Put them in your `config.fish`.
 You can also modify them on-the-fly if you want the changes to only affect your current shell session.
 
 * `set fish_command_timer_enabled`: Setting this variable to `0` disables
-  printing of timing and exit status information.
+  printing of all timing and exit status information.
 * `set fish_command_timer_status_enabled`: Setting this variable to `0`
   disables printing of exit status information.
 * `set fish_command_timer_color blue`: The color to use for timing information.
@@ -67,4 +67,12 @@ You can also modify them on-the-fly if you want the changes to only affect your 
 * `set fish_command_timer_export_cmd_duration_str`: If set to `1`, will export
   the total command execution time string to `$CMD_DURATION_STR`, for use in
   prompts. If set to `0`, the `$CMD_DURATION_STR` variable will not be exported.
+* `set fish_command_timer_min_cmd_duration`: The minimum command duration (in
+  milliseconds) that should trigger printing of command timing information.
+  Commands that complete within the specified number of milliseconds will not
+  trigger printing of command timing information.
+  - Note that when `fish_command_timer_status_enabled` is set, commands that
+    exit with a non-zero status will always trigger printing of command timing
+    and exit status information even if they complete within
+    `$fish_command_timer_min_cmd_duration`.
 

--- a/conf.d/fish_command_timer.fish
+++ b/conf.d/fish_command_timer.fish
@@ -37,9 +37,9 @@
 if not set -q fish_command_timer_enabled
   set fish_command_timer_enabled 1
 end
-# Whether to display the exit status of the previous command line.
+# Whether to display the exit status of the previous command.
 if not set -q fish_command_timer_status_enabled
-  set fish_command_timer_status_enabled 1
+  set fish_command_timer_status_enabled 0
 end
 
 # The color of the output.
@@ -92,6 +92,15 @@ if begin
      [ "$fish_command_timer_export_cmd_duration_str" -ne 0 ]
    end
   set CMD_DURATION_STR
+end
+
+# The minimum command duration that should trigger printing of command timings,
+# in milliseconds.
+#
+# When set to a non-zero value, commands that finished within the specified
+# number of milliseconds will not trigger printing of command timings.
+if not set -q fish_command_timer_min_cmd_duration
+  set fish_command_timer_min_cmd_duration 0
 end
 
 
@@ -212,6 +221,15 @@ function fish_command_timer_postexec -e fish_postexec
       end
     return
   end
+  if set -q fish_command_timer_min_cmd_duration; and \
+      [ "$fish_command_timer_min_cmd_duration" -gt "$CMD_DURATION" ]; and begin
+        [ "$last_status" -eq 0 ]; or \
+        not set -q fish_command_timer_status_enabled; or \
+        [ "$fish_command_timer_status_enabled" -eq 0 ]
+      end
+    return
+  end
+
 
   # Compute timing string (e.g. [ 1s016 | Oct 01 11:11PM ])
   set -l timing_str


### PR DESCRIPTION
Closes #24 

This PR adds a new setting, `fish_command_timer_min_cmd_duration`. Commands that exit within the specified number of milliseconds won't trigger printing of timing info.