### PR TITLE
__fish_status_to_signal function renamed

### DIFF
--- a/conf.d/fish_command_timer.fish
+++ b/conf.d/fish_command_timer.fish
@@ -258,7 +258,7 @@ function fish_command_timer_postexec -e fish_postexec
       set -q fish_command_timer_status_enabled; and \
       [ "$fish_command_timer_status_enabled" -ne 0 ]
      end
-    set -l signal (__fish_status_to_signal $last_status)
+    set -l signal (fish_status_to_signal $last_status)
     set status_str "[ $signal ]"
   end
   set -l status_str_length (fish_command_timer_strlen "$status_str")


### PR DESCRIPTION
From fish shell 3.2.0, __fish_status_to_signal function  has been changed to fish_status_to_signal
https://github.com/fish-shell/fish-shell/pull/7597